### PR TITLE
Protobuf DenimMessage definition and  decode for deniable_payload

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -3,8 +3,12 @@ coverage:
   precision: 2
   status:
     project:
-      default:   # default is the status check's name, not default settings
-        target: 80 
+      default: # default is the status check's name, not default settings
+        target: 80
+        threshold: 20
+    patch:
+      default:
+        target: 80
         threshold: 20
 
 ignore:

--- a/common/build.rs
+++ b/common/build.rs
@@ -9,6 +9,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .type_attribute("SeedUpdate", "#[derive(bon::Builder)]")
         .type_attribute("Error", "#[derive(bon::Builder)]")
         .type_attribute("DummyPadding", "#[derive(bon::Builder)]")
+        .type_attribute("DenimMessage", "#[derive(bon::Builder)]")
         .include_file("_includes.rs")
         .compile_protos(&["proto/DenimMessage.proto"], &["proto"])?;
 

--- a/common/proto/DenimMessage.proto
+++ b/common/proto/DenimMessage.proto
@@ -73,6 +73,6 @@ message KeyBundle {
 }
 
 message DenimMessage {
-  required bytes sam_message = 1;
+  required bytes regular_payload = 1;
   repeated bytes deniable_payload = 2;
 }

--- a/common/proto/DenimMessage.proto
+++ b/common/proto/DenimMessage.proto
@@ -71,3 +71,8 @@ message KeyBundle {
   required SignedKeyStruct pq_pre_key = 4;
   required SignedKeyStruct signed_pre_key = 5;
 }
+
+message DenimMessage {
+  required bytes sam_message = 1;
+  repeated bytes deniable_payload = 2;
+}

--- a/common/src/buffers/in_mem/send.rs
+++ b/common/src/buffers/in_mem/send.rs
@@ -83,7 +83,7 @@ impl SendingBuffer for InMemorySendingBuffer {
         if available_bytes > 0 {
             denim_chunks
                 .last_mut()
-                .ok_or(LibError::IllegalDeniablePayload)?
+                .ok_or(LibError::NoChunksInDeniablePayload)?
                 .set_garbage_flag();
             return Ok(Some(
                 DeniablePayload::builder()
@@ -115,13 +115,13 @@ impl InMemorySendingBuffer {
         let chunk_size_without_payload = DenimChunk::get_size_without_payload();
 
         if min_payload_length as usize > chunk_size_without_payload {
-            return Err(LibError::IllegalMinPayloadLength);
+            return Err(LibError::MinPayloadLengthTooHigh);
         }
 
         Ok(Self {
             min_payload_length,
             q,
-            chunk_size_without_payload: chunk_size_without_payload,
+            chunk_size_without_payload,
             outgoing_messages: Arc::new(Mutex::new(VecDeque::new())),
             buffer: Arc::new(Mutex::new(Buffer {
                 content: Vec::new(),

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -7,6 +7,6 @@ pub enum LibError {
     DenimMessageDecode(ChunkDecodeError),
     ChunkDecode,
     ChunkEncode,
-    IllegalMinPayloadLength,
-    IllegalDeniablePayload,
+    MinPayloadLengthTooHigh,
+    NoChunksInDeniablePayload,
 }

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -7,4 +7,6 @@ pub enum LibError {
     DenimMessageDecode(ChunkDecodeError),
     ChunkDecode,
     ChunkEncode,
+    IllegalMinPayloadLength,
+    IllegalDeniablePayload,
 }

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -4,6 +4,7 @@ use crate::buffers::ChunkDecodeError;
 
 #[derive(Debug, Display, Error)]
 pub enum LibError {
-    ChunkDecode(ChunkDecodeError),
+    DenimMessageDecode(ChunkDecodeError),
+    ChunkDecode,
     ChunkEncode,
 }

--- a/common/tests/buffers.rs
+++ b/common/tests/buffers.rs
@@ -43,7 +43,7 @@ pub async fn send_recv_buffer(
 ) {
     let _ = env_logger::try_init();
     let deniable_messages = make_deniable_messages(message_lengths.clone());
-    let mut sending_buffer = InMemorySendingBuffer::new(q, 10);
+    let mut sending_buffer = InMemorySendingBuffer::new(q, 10).expect("Can make SendingBuffer");
 
     for message in deniable_messages {
         sending_buffer.enqueue_message(message).await;


### PR DESCRIPTION
This pr entails:

- A decode function used to decode the deniable payload, and get a `Vec<DenimChunk>` that should be given to the `ReceivingBuffer.process_chunks()`
- Added protobuf for DenimMessage. This is the message sent over websocket, it has a sam_message and a deniable_payload
- Added garbage flags, indicating that the next bytes in the deniable payload are garbage and should not be decoded. This is used in the decode function