### PR TITLE
Client Key Response Handling

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -398,13 +398,7 @@ impl<T: DenimClientType> DenimClient<T> {
     ) -> Result<(), DenimClientError> {
         self.protocol_client
             .enqueue_deniable(MessageKind::DeniableMessage(
-                encrypt(
-                    msg.into(),
-                    recipient,
-                    &mut self.store,
-                    &mut self.deniable_store,
-                )
-                .await?,
+                encrypt(msg, recipient, &mut self.store, &mut self.deniable_store).await?,
             ))
             .await;
         Ok(())

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -27,7 +27,7 @@ use tokio::sync::broadcast::Receiver;
 
 use crate::encryption::encrypt::encrypt;
 use crate::error::DenimClientError;
-use crate::message::process::process_deniable_message;
+use crate::message::process::{process_deniable_message, DenimResponse};
 use crate::message::queue::InMemoryMessageQueue;
 use crate::message::traits::{MessageQueue, MessageQueueConfig};
 use crate::protocol::{
@@ -388,7 +388,14 @@ impl<T: DenimClientType> DenimClient<T> {
             self.waiting_messages.enqueue(recipient, msg.into()).await;
             return Ok(());
         }
+        self.enqueue_deniable(recipient, msg.into()).await
+    }
 
+    async fn enqueue_deniable(
+        &mut self,
+        recipient: AccountId,
+        msg: Vec<u8>,
+    ) -> Result<(), DenimClientError> {
         self.protocol_client
             .enqueue_deniable(MessageKind::DeniableMessage(
                 encrypt(
@@ -436,7 +443,7 @@ impl<T: DenimClientType> DenimClient<T> {
             return Ok(());
         }
         while let Some(envelope) = self.envelope_queue.recv().await {
-            match envelope {
+            let denim_res = match envelope {
                 SamDenimMessage::Denim(den) => {
                     process_deniable_message(
                         den,
@@ -444,10 +451,17 @@ impl<T: DenimClientType> DenimClient<T> {
                         &mut self.deniable_store,
                         &mut self.rng,
                     )
-                    .await?;
+                    .await?
                 }
                 SamDenimMessage::Sam(env) => {
                     process_message(env, &mut self.store).await?;
+                    None
+                }
+            };
+            if let Some(DenimResponse::KeyResponse(account_id)) = denim_res {
+                let message = self.waiting_messages.dequeue(account_id).await;
+                if let Some(bytes) = message {
+                    self.enqueue_deniable(account_id, bytes).await?;
                 }
             }
             if self.envelope_queue.is_empty() {

--- a/client/src/message/error.rs
+++ b/client/src/message/error.rs
@@ -1,8 +1,9 @@
 use denim_sam_common::DenimBufferError;
 use derive_more::{Display, Error, From};
+use libsignal_protocol::SignalProtocolError;
 use sam_client::storage::error::MessageStoreError;
 
-use crate::encryption::error::EncryptionError;
+use crate::encryption::error::{EncryptionError, KeyError};
 
 #[derive(Debug, Error, Display, From)]
 pub enum MessageError {
@@ -16,5 +17,7 @@ pub enum MessageProcessingError {
     MalformedMessage,
     MessageStore(MessageStoreError),
     EncryptionError(EncryptionError),
+    KeyError(KeyError),
+    SignalProtocolError(SignalProtocolError),
     ServerError(#[error(not(source))] String),
 }

--- a/client/src/message/process.rs
+++ b/client/src/message/process.rs
@@ -1,33 +1,44 @@
+use std::time::SystemTime;
+
 use denim_sam_common::denim_message::{
     deniable_message::MessageKind, DeniableMessage, KeyResponse,
 };
+use libsignal_core::ProtocolAddress;
+use libsignal_protocol::{process_prekey_bundle, IdentityKey};
+use log::debug;
 use rand::{CryptoRng, Rng};
 use sam_client::storage::{MessageStore, Store, StoreType};
 use sam_common::AccountId;
 
 use crate::{
-    encryption::encrypt::decrypt,
+    encryption::{encrypt::decrypt, into_libsignal_bundle},
     store::{DeniableStore, DeniableStoreType},
 };
 
 use super::error::MessageProcessingError;
+
+pub enum DenimResponse {
+    KeyResponse(AccountId),
+}
 
 pub async fn process_deniable_message<R: Rng + CryptoRng>(
     message: DeniableMessage,
     store: &mut Store<impl StoreType>,
     deniable_store: &mut DeniableStore<impl DeniableStoreType>,
     rng: &mut R,
-) -> Result<(), MessageProcessingError> {
+) -> Result<Option<DenimResponse>, MessageProcessingError> {
     let kind = message
         .message_kind
         .ok_or(MessageProcessingError::MessageKindWasNone)?;
+
     let envelope = match kind {
         MessageKind::DeniableMessage(message) => {
             decrypt(message, store, deniable_store, rng).await?
         }
         MessageKind::KeyResponse(res) => {
-            handle_key_response(res, store, deniable_store, rng).await?;
-            return Ok(());
+            return handle_key_response(res, store, deniable_store, rng)
+                .await
+                .map(Some);
         }
         MessageKind::Error(error) => {
             let account_id = AccountId::try_from(error.account_id().to_vec())
@@ -41,14 +52,31 @@ pub async fn process_deniable_message<R: Rng + CryptoRng>(
     };
 
     deniable_store.message_store.store_message(envelope).await?;
-    Ok(())
+    Ok(None)
 }
 
 async fn handle_key_response<R: Rng + CryptoRng>(
-    _response: KeyResponse,
-    _store: &mut Store<impl StoreType>,
-    _deniable_store: &mut DeniableStore<impl DeniableStoreType>,
-    _rng: &mut R,
-) -> Result<(), MessageProcessingError> {
-    todo!("Implement this when proxy implements denim routing")
+    response: KeyResponse,
+    store: &mut Store<impl StoreType>,
+    deniable_store: &mut DeniableStore<impl DeniableStoreType>,
+    rng: &mut R,
+) -> Result<DenimResponse, MessageProcessingError> {
+    let account_id = AccountId::try_from(response.account_id)
+        .inspect_err(|e| debug!("{e}"))
+        .map_err(|_| MessageProcessingError::MalformedMessage)?;
+    let id_key = IdentityKey::decode(&response.identity_key)?;
+    let device_id = response.key_bundle.device_id;
+
+    let signal_bundle = into_libsignal_bundle(&id_key, response.key_bundle)?;
+    let addr = ProtocolAddress::new(account_id.to_string(), device_id.into());
+    process_prekey_bundle(
+        &addr,
+        &mut deniable_store.session_store,
+        &mut store.identity_key_store,
+        &signal_bundle,
+        SystemTime::now(),
+        rng,
+    )
+    .await?;
+    Ok(DenimResponse::KeyResponse(account_id))
 }

--- a/common/proto/DenimMessage.proto
+++ b/common/proto/DenimMessage.proto
@@ -21,8 +21,9 @@ message KeyRequest {
 }
 
 message KeyResponse {
-  required bytes identity_key = 1;
-  repeated KeyBundle key_bundle = 2;
+  required bytes account_id = 1;
+  required bytes identity_key = 2;  
+  required KeyBundle key_bundle = 3;
 }
 
 message KeyUpdate { required bytes signed_pre_key = 1; }

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -75,7 +75,12 @@ async fn sam_server_handler<T: StateType>(
     account_id: AccountId,
 ) {
     // SAM Server sends proxy a message
-    while let Some(AxumMessage::Binary(msg)) = server_receiver.recv().await {
+    while let Some(msg) = server_receiver.recv().await {
+        let msg = match msg {
+            AxumMessage::Binary(msg) => msg,
+            AxumMessage::Close(_) => break,
+            _ => continue,
+        };
         let len = match msg.len().try_into() {
             Ok(len) => len,
             Err(_) => {
@@ -131,7 +136,12 @@ async fn denim_client_receiver<T: StateType>(
     account_id: AccountId,
 ) {
     // Client sends proxy a message
-    while let Some(Ok(AxumMessage::Binary(msg))) = client_receiver.next().await {
+    while let Some(Ok(msg)) = client_receiver.next().await {
+        let msg = match msg {
+            AxumMessage::Binary(msg) => msg,
+            AxumMessage::Close(_) => break,
+            _ => continue,
+        };
         let msg = match DenimMessage::decode(msg.to_vec()) {
             Ok(msg) => msg,
             Err(e) => {


### PR DESCRIPTION
- Client now handles key responses from proxy
- Proxy while loops have been fixed
closes #36 

note: This can first be tested when postgres managers have been made on SAM