### PR TITLE
Crypto Provider for any crypto rngs

### DIFF
--- a/proxy/src/logic/keys.rs
+++ b/proxy/src/logic/keys.rs
@@ -24,7 +24,7 @@ pub async fn get_keys_for<T: StateType>(
     let pre_key = state
         .keys
         .pre_keys
-        .get_ec_pre_key(account_id, device_id)
+        .get_ec_pre_key(account_id, device_id, &state.crypto_provider)
         .await?
         .encode()
         .map_err(|err| {
@@ -263,7 +263,7 @@ mod test {
         assert!(state
             .keys
             .pre_keys
-            .get_ec_pre_key(account_id, device_id)
+            .get_ec_pre_key(account_id, device_id, &state.crypto_provider)
             .await
             .is_ok());
 

--- a/proxy/src/logic/keys.rs
+++ b/proxy/src/logic/keys.rs
@@ -24,7 +24,7 @@ pub async fn get_keys_for<T: StateType>(
     let pre_key = state
         .keys
         .pre_keys
-        .get_ec_pre_key(account_id, device_id, &state.crypto_provider)
+        .get_ec_pre_key::<T::CryptoProvider, T::Rng>(account_id, device_id)
         .await?
         .encode()
         .map_err(|err| {
@@ -114,7 +114,7 @@ mod test {
     use crate::{
         error::LogicError,
         logic::keys::get_keys_for,
-        managers::{DenimEcPreKeyManager, DenimKeyManagerError},
+        managers::{default::ChaChaCryptoProvider, DenimEcPreKeyManager, DenimKeyManagerError},
         state::{DenimState, InMemoryStateType},
     };
 
@@ -263,7 +263,7 @@ mod test {
         assert!(state
             .keys
             .pre_keys
-            .get_ec_pre_key(account_id, device_id, &state.crypto_provider)
+            .get_ec_pre_key::<ChaChaCryptoProvider, ChaCha20Rng>(account_id, device_id)
             .await
             .is_ok());
 

--- a/proxy/src/logic/keys.rs
+++ b/proxy/src/logic/keys.rs
@@ -24,7 +24,7 @@ pub async fn get_keys_for<T: StateType>(
     let pre_key = state
         .keys
         .pre_keys
-        .get_ec_pre_key::<T::CryptoProvider, T::Rng>(account_id, device_id)
+        .get_ec_pre_key::<T::CryptoProvider>(account_id, device_id)
         .await?
         .encode()
         .map_err(|err| {
@@ -263,7 +263,7 @@ mod test {
         assert!(state
             .keys
             .pre_keys
-            .get_ec_pre_key::<ChaChaCryptoProvider, ChaCha20Rng>(account_id, device_id)
+            .get_ec_pre_key::<ChaChaCryptoProvider>(account_id, device_id)
             .await
             .is_ok());
 

--- a/proxy/src/managers/default/crypto_provider.rs
+++ b/proxy/src/managers/default/crypto_provider.rs
@@ -5,15 +5,15 @@ use rand_chacha::ChaCha20Rng;
 
 use crate::managers::traits::CryptoProvider;
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct ChaChaCryptoProvider;
 
 #[async_trait]
 impl CryptoProvider<ChaCha20Rng> for ChaChaCryptoProvider {
-    async fn get_seeded(&self, seed: Seed) -> ChaCha20Rng {
+    async fn get_seeded(seed: Seed) -> ChaCha20Rng {
         ChaCha20Rng::from_seed(*seed)
     }
-    async fn get_seeded_with_offset(&self, seed: Seed, offset: u128) -> ChaCha20Rng {
+    async fn get_seeded_with_offset(seed: Seed, offset: u128) -> ChaCha20Rng {
         let mut csprng = ChaCha20Rng::from_seed(*seed);
         csprng.set_word_pos(offset);
         csprng

--- a/proxy/src/managers/default/crypto_provider.rs
+++ b/proxy/src/managers/default/crypto_provider.rs
@@ -9,7 +9,8 @@ use crate::managers::traits::CryptoProvider;
 pub struct ChaChaCryptoProvider;
 
 #[async_trait]
-impl CryptoProvider<ChaCha20Rng> for ChaChaCryptoProvider {
+impl CryptoProvider for ChaChaCryptoProvider {
+    type Rng = ChaCha20Rng;
     fn get_seeded(seed: Seed) -> ChaCha20Rng {
         ChaCha20Rng::from_seed(*seed)
     }

--- a/proxy/src/managers/default/crypto_provider.rs
+++ b/proxy/src/managers/default/crypto_provider.rs
@@ -1,0 +1,25 @@
+use async_trait::async_trait;
+use denim_sam_common::Seed;
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+
+use crate::managers::traits::CryptoProvider;
+
+#[derive(Clone, Default)]
+pub struct ChaChaProvider;
+
+#[async_trait]
+impl CryptoProvider<ChaCha20Rng> for ChaChaProvider {
+    async fn get_seeded(&self, seed: Seed) -> ChaCha20Rng {
+        ChaCha20Rng::from_seed(*seed)
+    }
+    async fn get_seeded_with_offset(&self, seed: Seed, offset: u128) -> ChaCha20Rng {
+        let mut csprng = ChaCha20Rng::from_seed(*seed);
+        csprng.set_word_pos(offset);
+        csprng
+    }
+
+    async fn extract_seed_offset(csprng: ChaCha20Rng) -> (Seed, u128) {
+        (csprng.get_seed().into(), csprng.get_word_pos())
+    }
+}

--- a/proxy/src/managers/default/crypto_provider.rs
+++ b/proxy/src/managers/default/crypto_provider.rs
@@ -6,10 +6,10 @@ use rand_chacha::ChaCha20Rng;
 use crate::managers::traits::CryptoProvider;
 
 #[derive(Clone, Default)]
-pub struct ChaChaProvider;
+pub struct ChaChaCryptoProvider;
 
 #[async_trait]
-impl CryptoProvider<ChaCha20Rng> for ChaChaProvider {
+impl CryptoProvider<ChaCha20Rng> for ChaChaCryptoProvider {
     async fn get_seeded(&self, seed: Seed) -> ChaCha20Rng {
         ChaCha20Rng::from_seed(*seed)
     }

--- a/proxy/src/managers/default/crypto_provider.rs
+++ b/proxy/src/managers/default/crypto_provider.rs
@@ -10,16 +10,16 @@ pub struct ChaChaCryptoProvider;
 
 #[async_trait]
 impl CryptoProvider<ChaCha20Rng> for ChaChaCryptoProvider {
-    async fn get_seeded(seed: Seed) -> ChaCha20Rng {
+    fn get_seeded(seed: Seed) -> ChaCha20Rng {
         ChaCha20Rng::from_seed(*seed)
     }
-    async fn get_seeded_with_offset(seed: Seed, offset: u128) -> ChaCha20Rng {
+    fn get_seeded_with_offset(seed: Seed, offset: u128) -> ChaCha20Rng {
         let mut csprng = ChaCha20Rng::from_seed(*seed);
         csprng.set_word_pos(offset);
         csprng
     }
 
-    async fn extract_seed_offset(csprng: ChaCha20Rng) -> (Seed, u128) {
+    fn extract_seed_offset(csprng: &ChaCha20Rng) -> (Seed, u128) {
         (csprng.get_seed().into(), csprng.get_word_pos())
     }
 }

--- a/proxy/src/managers/default/key_gen.rs
+++ b/proxy/src/managers/default/key_gen.rs
@@ -1,11 +1,9 @@
-use rand::{CryptoRng, Rng};
-
 use sam_common::{api::EcPreKey, AccountId, DeviceId};
 use sam_security::key_gen::generate_ec_pre_key;
 
 use crate::managers::{traits::CryptoProvider, DenimEcPreKeyManager, DenimKeyManagerError};
 
-pub async fn generate_ec_pre_keys<C: CryptoProvider<R>, R: CryptoRng + Rng>(
+pub async fn generate_ec_pre_keys<C: CryptoProvider>(
     key_manager: &mut impl DenimEcPreKeyManager,
     account_id: AccountId,
     device_id: DeviceId,

--- a/proxy/src/managers/default/key_gen.rs
+++ b/proxy/src/managers/default/key_gen.rs
@@ -1,3 +1,5 @@
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
 use sam_common::{api::EcPreKey, AccountId, DeviceId};
 use sam_security::key_gen::generate_ec_pre_key;
 
@@ -9,7 +11,9 @@ pub async fn generate_ec_pre_keys(
     device_id: DeviceId,
     amount: usize,
 ) -> Result<(), DenimKeyManagerError> {
-    let mut csprng = key_manager.get_csprng_for(account_id, device_id).await?;
+    let (seed, offset) = key_manager.get_csprng_for(account_id, device_id).await?;
+    let mut csprng = ChaCha20Rng::from_seed(*seed);
+    csprng.set_word_pos(offset);
     for _ in 0..amount {
         let pk: EcPreKey = generate_ec_pre_key(
             key_manager.next_key_id(account_id, device_id).await?.into(),
@@ -20,8 +24,10 @@ pub async fn generate_ec_pre_keys(
         key_manager
             .add_ec_pre_key(account_id, device_id, pk.clone())
             .await?;
+
+        let (seed, offset) = (csprng.get_seed().into(), csprng.get_word_pos());
         key_manager
-            .store_csprng_for(account_id, device_id, &csprng)
+            .store_csprng_for(account_id, device_id, seed, offset)
             .await?;
     }
     Ok(())

--- a/proxy/src/managers/default/key_gen.rs
+++ b/proxy/src/managers/default/key_gen.rs
@@ -1,12 +1,13 @@
-use rand::SeedableRng;
+use rand::{CryptoRng, Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use sam_common::{api::EcPreKey, AccountId, DeviceId};
 use sam_security::key_gen::generate_ec_pre_key;
 
-use crate::managers::{DenimEcPreKeyManager, DenimKeyManagerError};
+use crate::managers::{traits::CryptoProvider, DenimEcPreKeyManager, DenimKeyManagerError};
 
-pub async fn generate_ec_pre_keys(
+pub async fn generate_ec_pre_keys<R: CryptoRng + Rng>(
     key_manager: &mut impl DenimEcPreKeyManager,
+    _crypto_provider: &impl CryptoProvider<R>,
     account_id: AccountId,
     device_id: DeviceId,
     amount: usize,

--- a/proxy/src/managers/default/mod.rs
+++ b/proxy/src/managers/default/mod.rs
@@ -1,5 +1,7 @@
 mod buffer_manager;
+mod crypto_provider;
 mod key_gen;
 
 pub use buffer_manager::{BufferManager, ClientRequest};
+pub use crypto_provider::ChaChaProvider;
 pub use key_gen::generate_ec_pre_keys;

--- a/proxy/src/managers/default/mod.rs
+++ b/proxy/src/managers/default/mod.rs
@@ -3,5 +3,5 @@ mod crypto_provider;
 mod key_gen;
 
 pub use buffer_manager::{BufferManager, ClientRequest};
-pub use crypto_provider::ChaChaProvider;
+pub use crypto_provider::ChaChaCryptoProvider;
 pub use key_gen::generate_ec_pre_keys;

--- a/proxy/src/managers/in_mem/keys.rs
+++ b/proxy/src/managers/in_mem/keys.rs
@@ -1,8 +1,7 @@
 use async_trait::async_trait;
 use denim_sam_common::Seed;
 use futures_util::TryFutureExt;
-use rand::{rngs::OsRng, RngCore, SeedableRng};
-use rand_chacha::ChaCha20Rng;
+use rand::{rngs::OsRng, RngCore};
 use sam_common::{address::DeviceAddress, api::EcPreKey, AccountId, DeviceId};
 use sam_server::managers::{
     in_memory::keys::{InMemoryEcPreKeyManager, InMemorySignedPreKeyManager},
@@ -131,7 +130,7 @@ impl DenimEcPreKeyManager for InMemoryDenimEcPreKeyManager {
         &self,
         account_id: AccountId,
         device_id: DeviceId,
-    ) -> Result<ChaCha20Rng, DenimKeyManagerError> {
+    ) -> Result<(Seed, u128), DenimKeyManagerError> {
         let res = self
             .seeds
             .lock()
@@ -139,21 +138,17 @@ impl DenimEcPreKeyManager for InMemoryDenimEcPreKeyManager {
             .get(&DeviceAddress::new(account_id, device_id))
             .cloned()
             .ok_or(DenimKeyManagerError::NoSeed)?;
-        let (seed, offset) = res;
-        let mut csprng = ChaCha20Rng::from_seed(*seed);
-        csprng.set_word_pos(offset);
-        Ok(csprng)
+
+        Ok(res)
     }
 
     async fn store_csprng_for(
         &mut self,
         account_id: AccountId,
         device_id: DeviceId,
-        csprng: &ChaCha20Rng,
+        seed: Seed,
+        offset: u128,
     ) -> Result<(), DenimKeyManagerError> {
-        let seed = csprng.get_seed();
-        let offset = csprng.get_word_pos();
-
         self.seeds.lock().await.insert(
             DeviceAddress::new(account_id, device_id),
             (seed.into(), offset),

--- a/proxy/src/managers/in_mem/keys.rs
+++ b/proxy/src/managers/in_mem/keys.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use denim_sam_common::Seed;
 use futures_util::TryFutureExt;
-use rand::{rngs::OsRng, RngCore};
+use rand::{rngs::OsRng, CryptoRng, Rng, RngCore};
 use sam_common::{address::DeviceAddress, api::EcPreKey, AccountId, DeviceId};
 use sam_server::managers::{
     in_memory::keys::{InMemoryEcPreKeyManager, InMemorySignedPreKeyManager},
@@ -11,7 +11,8 @@ use std::{collections::HashMap, sync::Arc};
 use tokio::sync::Mutex;
 
 use crate::managers::{
-    default::generate_ec_pre_keys, DenimEcPreKeyManager, DenimKeyManagerError, DenimKeyManagerType,
+    default::generate_ec_pre_keys, traits::CryptoProvider, DenimEcPreKeyManager,
+    DenimKeyManagerError, DenimKeyManagerType,
 };
 
 #[derive(Clone)]
@@ -44,15 +45,23 @@ impl Default for InMemoryDenimEcPreKeyManager {
 
 #[async_trait]
 impl DenimEcPreKeyManager for InMemoryDenimEcPreKeyManager {
-    async fn get_ec_pre_key(
+    async fn get_ec_pre_key<R: CryptoRng + Rng>(
         &mut self,
         account_id: AccountId,
         device_id: DeviceId,
+        crypto_provider: &impl CryptoProvider<R>,
     ) -> Result<EcPreKey, DenimKeyManagerError> {
         if let Some(pk) = self.manager.get_pre_key(account_id, device_id).await? {
             Ok(pk)
         } else {
-            generate_ec_pre_keys(self, account_id, device_id, self.key_generate_amount).await?;
+            generate_ec_pre_keys(
+                self,
+                crypto_provider,
+                account_id,
+                device_id,
+                self.key_generate_amount,
+            )
+            .await?;
             self.manager
                 .get_pre_key(account_id, device_id)
                 .await?

--- a/proxy/src/managers/traits/crypto_provider.rs
+++ b/proxy/src/managers/traits/crypto_provider.rs
@@ -1,0 +1,10 @@
+use async_trait::async_trait;
+use denim_sam_common::Seed;
+use rand::{CryptoRng, Rng};
+
+#[async_trait]
+pub trait CryptoProvider<R: CryptoRng + Rng>: Clone + Send + Sync {
+    async fn get_seeded(&self, seed: Seed) -> R;
+    async fn get_seeded_with_offset(&self, seed: Seed, offset: u128) -> R;
+    async fn extract_seed_offset(csprng: R) -> (Seed, u128);
+}

--- a/proxy/src/managers/traits/crypto_provider.rs
+++ b/proxy/src/managers/traits/crypto_provider.rs
@@ -4,7 +4,7 @@ use rand::{CryptoRng, Rng};
 
 #[async_trait]
 pub trait CryptoProvider<R: CryptoRng + Rng>: Clone + Send + Sync {
-    async fn get_seeded(&self, seed: Seed) -> R;
-    async fn get_seeded_with_offset(&self, seed: Seed, offset: u128) -> R;
+    async fn get_seeded(seed: Seed) -> R;
+    async fn get_seeded_with_offset(seed: Seed, offset: u128) -> R;
     async fn extract_seed_offset(csprng: R) -> (Seed, u128);
 }

--- a/proxy/src/managers/traits/crypto_provider.rs
+++ b/proxy/src/managers/traits/crypto_provider.rs
@@ -3,8 +3,9 @@ use denim_sam_common::Seed;
 use rand::{CryptoRng, Rng};
 
 #[async_trait]
-pub trait CryptoProvider<R: CryptoRng + Rng>: Clone + Send + Sync {
-    fn get_seeded(seed: Seed) -> R;
-    fn get_seeded_with_offset(seed: Seed, offset: u128) -> R;
-    fn extract_seed_offset(csprng: &R) -> (Seed, u128);
+pub trait CryptoProvider: Clone + Send + Sync {
+    type Rng: CryptoRng + Rng + Send;
+    fn get_seeded(seed: Seed) -> Self::Rng;
+    fn get_seeded_with_offset(seed: Seed, offset: u128) -> Self::Rng;
+    fn extract_seed_offset(csprng: &Self::Rng) -> (Seed, u128);
 }

--- a/proxy/src/managers/traits/crypto_provider.rs
+++ b/proxy/src/managers/traits/crypto_provider.rs
@@ -4,7 +4,7 @@ use rand::{CryptoRng, Rng};
 
 #[async_trait]
 pub trait CryptoProvider<R: CryptoRng + Rng>: Clone + Send + Sync {
-    async fn get_seeded(seed: Seed) -> R;
-    async fn get_seeded_with_offset(seed: Seed, offset: u128) -> R;
-    async fn extract_seed_offset(csprng: R) -> (Seed, u128);
+    fn get_seeded(seed: Seed) -> R;
+    fn get_seeded_with_offset(seed: Seed, offset: u128) -> R;
+    fn extract_seed_offset(csprng: &R) -> (Seed, u128);
 }

--- a/proxy/src/managers/traits/keys.rs
+++ b/proxy/src/managers/traits/keys.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
+use denim_sam_common::Seed;
 use derive_more::{Display, Error, From};
-use rand_chacha::ChaCha20Rng;
+
 use sam_common::{api::EcPreKey, AccountId, DeviceId};
 use sam_server::managers::error::KeyManagerError;
 
@@ -50,12 +51,13 @@ pub trait DenimEcPreKeyManager: Clone + Send + Sync {
         &self,
         account_id: AccountId,
         device_id: DeviceId,
-    ) -> Result<ChaCha20Rng, DenimKeyManagerError>;
+    ) -> Result<(Seed, u128), DenimKeyManagerError>;
 
     async fn store_csprng_for(
         &mut self,
         account_id: AccountId,
         device_id: DeviceId,
-        csprng: &ChaCha20Rng,
+        seed: Seed,
+        offset: u128,
     ) -> Result<(), DenimKeyManagerError>;
 }

--- a/proxy/src/managers/traits/keys.rs
+++ b/proxy/src/managers/traits/keys.rs
@@ -18,11 +18,10 @@ pub enum DenimKeyManagerError {
 
 #[async_trait]
 pub trait DenimEcPreKeyManager: Clone + Send + Sync {
-    async fn get_ec_pre_key<R: CryptoRng + Rng>(
+    async fn get_ec_pre_key<C: CryptoProvider<R>, R: CryptoRng + Rng + Send>(
         &mut self,
         account_id: AccountId,
         device_id: DeviceId,
-        crypto_provider: &impl CryptoProvider<R>,
     ) -> Result<EcPreKey, DenimKeyManagerError>;
 
     async fn get_ec_pre_key_ids(

--- a/proxy/src/managers/traits/keys.rs
+++ b/proxy/src/managers/traits/keys.rs
@@ -2,8 +2,11 @@ use async_trait::async_trait;
 use denim_sam_common::Seed;
 use derive_more::{Display, Error, From};
 
+use rand::{CryptoRng, Rng};
 use sam_common::{api::EcPreKey, AccountId, DeviceId};
 use sam_server::managers::error::KeyManagerError;
+
+use super::CryptoProvider;
 
 #[derive(Debug, Display, Error, From)]
 pub enum DenimKeyManagerError {
@@ -15,10 +18,11 @@ pub enum DenimKeyManagerError {
 
 #[async_trait]
 pub trait DenimEcPreKeyManager: Clone + Send + Sync {
-    async fn get_ec_pre_key(
+    async fn get_ec_pre_key<R: CryptoRng + Rng>(
         &mut self,
         account_id: AccountId,
         device_id: DeviceId,
+        crypto_provider: &impl CryptoProvider<R>,
     ) -> Result<EcPreKey, DenimKeyManagerError>;
 
     async fn get_ec_pre_key_ids(

--- a/proxy/src/managers/traits/keys.rs
+++ b/proxy/src/managers/traits/keys.rs
@@ -2,7 +2,6 @@ use async_trait::async_trait;
 use denim_sam_common::Seed;
 use derive_more::{Display, Error, From};
 
-use rand::{CryptoRng, Rng};
 use sam_common::{api::EcPreKey, AccountId, DeviceId};
 use sam_server::managers::error::KeyManagerError;
 
@@ -18,7 +17,7 @@ pub enum DenimKeyManagerError {
 
 #[async_trait]
 pub trait DenimEcPreKeyManager: Clone + Send + Sync {
-    async fn get_ec_pre_key<C: CryptoProvider<R>, R: CryptoRng + Rng + Send>(
+    async fn get_ec_pre_key<C: CryptoProvider>(
         &mut self,
         account_id: AccountId,
         device_id: DeviceId,

--- a/proxy/src/managers/traits/mod.rs
+++ b/proxy/src/managers/traits/mod.rs
@@ -1,7 +1,9 @@
+mod crypto_provider;
 mod keys;
 mod message;
 mod message_id_provider;
 
+pub use crypto_provider::CryptoProvider;
 pub use keys::{DenimEcPreKeyManager, DenimKeyManagerError};
 pub use message::BufferManager;
 pub use message_id_provider::MessageIdProvider;

--- a/proxy/src/server.rs
+++ b/proxy/src/server.rs
@@ -60,7 +60,7 @@ impl DenimConfig<InMemoryStateType> {
                 // TODO: When adding postgres manager, connect for device manager should not take these
                 // params as they are already set by SAM.
                 InMemoryDeviceManager::new("Test".to_owned(), 120),
-                ChaChaCryptoProvider::default(),
+                ChaChaCryptoProvider,
             ),
         }
     }

--- a/proxy/src/server.rs
+++ b/proxy/src/server.rs
@@ -12,6 +12,7 @@ use sam_server::managers::in_memory::account::InMemoryAccountManager;
 use sam_server::managers::in_memory::device::InMemoryDeviceManager;
 use sam_server::managers::in_memory::keys::InMemorySignedPreKeyManager;
 
+use crate::managers::default::ChaChaCryptoProvider;
 use crate::managers::in_mem::InMemoryDenimEcPreKeyManager;
 use crate::managers::{BufferManager, DenimKeyManager, InMemoryMessageIdProvider};
 use crate::routes::websocket_endpoint;
@@ -59,6 +60,7 @@ impl DenimConfig<InMemoryStateType> {
                 // TODO: When adding postgres manager, connect for device manager should not take these
                 // params as they are already set by SAM.
                 InMemoryDeviceManager::new("Test".to_owned(), 120),
+                ChaChaCryptoProvider::default(),
             ),
         }
     }

--- a/proxy/src/server.rs
+++ b/proxy/src/server.rs
@@ -12,7 +12,6 @@ use sam_server::managers::in_memory::account::InMemoryAccountManager;
 use sam_server::managers::in_memory::device::InMemoryDeviceManager;
 use sam_server::managers::in_memory::keys::InMemorySignedPreKeyManager;
 
-use crate::managers::default::ChaChaCryptoProvider;
 use crate::managers::in_mem::InMemoryDenimEcPreKeyManager;
 use crate::managers::{BufferManager, DenimKeyManager, InMemoryMessageIdProvider};
 use crate::routes::websocket_endpoint;
@@ -60,7 +59,6 @@ impl DenimConfig<InMemoryStateType> {
                 // TODO: When adding postgres manager, connect for device manager should not take these
                 // params as they are already set by SAM.
                 InMemoryDeviceManager::new("Test".to_owned(), 120),
-                ChaChaCryptoProvider,
             ),
         }
     }

--- a/proxy/src/state/in_mem.rs
+++ b/proxy/src/state/in_mem.rs
@@ -1,7 +1,7 @@
 use denim_sam_common::buffers::in_mem::{
     InMemoryReceivingBufferConfig, InMemorySendingBufferConfig,
 };
-use rand_chacha::ChaCha20Rng;
+
 use sam_server::managers::in_memory::{
     account::InMemoryAccountManager, device::InMemoryDeviceManager,
 };
@@ -35,6 +35,5 @@ impl StateType for InMemoryStateType {
 
     type DeviceManger = InMemoryDeviceManager;
 
-    type Rng = ChaCha20Rng;
     type CryptoProvider = ChaChaCryptoProvider;
 }

--- a/proxy/src/state/in_mem.rs
+++ b/proxy/src/state/in_mem.rs
@@ -1,11 +1,14 @@
 use denim_sam_common::buffers::in_mem::{
     InMemoryReceivingBufferConfig, InMemorySendingBufferConfig,
 };
+use rand_chacha::ChaCha20Rng;
 use sam_server::managers::in_memory::{
     account::InMemoryAccountManager, device::InMemoryDeviceManager,
 };
 
-use crate::managers::{in_mem::InMemoryDenimKeyManager, InMemoryMessageIdProvider};
+use crate::managers::{
+    default::ChaChaCryptoProvider, in_mem::InMemoryDenimKeyManager, InMemoryMessageIdProvider,
+};
 
 use super::{BufferManagerType, StateType};
 
@@ -31,4 +34,7 @@ impl StateType for InMemoryStateType {
     type AccountManager = InMemoryAccountManager;
 
     type DeviceManger = InMemoryDeviceManager;
+
+    type Rng = ChaCha20Rng;
+    type CryptoProvider = ChaChaCryptoProvider;
 }

--- a/proxy/src/state/mod.rs
+++ b/proxy/src/state/mod.rs
@@ -3,8 +3,7 @@ use crate::managers::{
     traits::MessageIdProvider, BufferManager, DenimKeyManager, DenimKeyManagerType,
 };
 use denim_sam_common::buffers::{ReceivingBufferConfig, SendingBufferConfig};
-use rand::CryptoRng;
-use rand::Rng;
+
 use sam_server::managers::traits::{
     account_manager::AccountManager, device_manager::DeviceManager,
 };
@@ -26,8 +25,7 @@ pub trait StateType: 'static + Clone {
     type DenimKeyManagerType: DenimKeyManagerType;
     type AccountManager: AccountManager;
     type DeviceManger: DeviceManager;
-    type CryptoProvider: CryptoProvider<Self::Rng>;
-    type Rng: CryptoRng + Rng + Send;
+    type CryptoProvider: CryptoProvider;
 }
 
 #[derive(Clone)]
@@ -36,7 +34,6 @@ pub struct DenimState<T: StateType> {
     pub keys: DenimKeyManager<T::DenimKeyManagerType>,
     pub devices: T::DeviceManger,
     pub accounts: T::AccountManager,
-    pub crypto_provider: T::CryptoProvider,
 
     sam_addr: String,
     channel_buffer_size: usize,
@@ -52,7 +49,6 @@ impl<T: StateType> DenimState<T> {
         keys: DenimKeyManager<T::DenimKeyManagerType>,
         accounts: T::AccountManager,
         devices: T::DeviceManger,
-        crypto_provider: T::CryptoProvider,
     ) -> Self {
         Self {
             sam_addr,
@@ -62,7 +58,6 @@ impl<T: StateType> DenimState<T> {
             keys,
             devices,
             accounts,
-            crypto_provider,
         }
     }
 
@@ -88,10 +83,7 @@ impl<T: StateType> DenimState<T> {
             keys::InMemorySignedPreKeyManager,
         };
 
-        use crate::managers::{
-            default::ChaChaCryptoProvider, in_mem::InMemoryDenimEcPreKeyManager,
-            InMemoryMessageIdProvider,
-        };
+        use crate::managers::{in_mem::InMemoryDenimEcPreKeyManager, InMemoryMessageIdProvider};
         let rcfg = InMemoryReceivingBufferConfig;
         let scfg = InMemorySendingBufferConfig::builder().q(1.0).build();
         let id_provider = InMemoryMessageIdProvider::default();
@@ -108,7 +100,6 @@ impl<T: StateType> DenimState<T> {
             ),
             InMemoryAccountManager::default(),
             InMemoryDeviceManager::new("Test".to_owned(), 120),
-            ChaChaCryptoProvider,
         )
     }
 }

--- a/proxy/src/state/mod.rs
+++ b/proxy/src/state/mod.rs
@@ -108,7 +108,7 @@ impl<T: StateType> DenimState<T> {
             ),
             InMemoryAccountManager::default(),
             InMemoryDeviceManager::new("Test".to_owned(), 120),
-            ChaChaCryptoProvider::default(),
+            ChaChaCryptoProvider,
         )
     }
 }

--- a/proxy/src/state/mod.rs
+++ b/proxy/src/state/mod.rs
@@ -27,7 +27,7 @@ pub trait StateType: 'static + Clone {
     type AccountManager: AccountManager;
     type DeviceManger: DeviceManager;
     type CryptoProvider: CryptoProvider<Self::Rng>;
-    type Rng: CryptoRng + Rng;
+    type Rng: CryptoRng + Rng + Send;
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
- Denim Proxy does not depend directly on ChaCha anymore, developers can implement any seedable rng for denim using the CryptoProvider trait

closes #41 