### PR TITLE
Bug Fix: Non atomic q, q is now atomic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ bincode = "2.0.1"
 rand_chacha = "0.3.1"
 sqlx = "0.8.3"
 uuid = "1.16.0"
+atomic_float = "1.1.0"
 
 
 # Dev dependencies

--- a/client/src/protocol/denim_client.rs
+++ b/client/src/protocol/denim_client.rs
@@ -113,6 +113,7 @@ impl<T: SendingBuffer, U: ReceivingBuffer> DenimSamClient for DenimProtocolClien
     }
 
     async fn enqueue_deniable(&mut self, message: MessageKind) {
+        debug!("Enqueued {}", message);
         self.sending_buffer
             .enqueue_message(
                 DeniableMessage::builder()

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -20,5 +20,6 @@ rand = { workspace = true, features = ["std_rng"] }
 bincode = { workspace = true }
 libsignal-protocol = { workspace = true }
 rand_chacha = { workspace = true }
+atomic_float = { workspace = true }
 [build-dependencies]
 prost-build = { workspace = true }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -2,11 +2,13 @@ pub mod buffers;
 mod error;
 pub mod rng;
 
+use std::fmt::Display;
+
 pub use error::{ConversionError, DenimBufferError, DenimEncodeDecodeError};
 
 include!(concat!(env!("OUT_DIR"), "/_includes.rs"));
 
-use denim_message::{MessageType, UserMessage};
+use denim_message::{deniable_message::MessageKind, MessageType, UserMessage};
 use libsignal_protocol::{
     CiphertextMessage, CiphertextMessageType, PlaintextContent, PreKeySignalMessage,
     SenderKeyMessage, SignalMessage, SignalProtocolError,
@@ -50,5 +52,18 @@ impl UserMessage {
                 PlaintextContent::try_from(self.content.as_slice())?,
             ),
         })
+    }
+}
+
+impl Display for MessageKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MessageKind::DeniableMessage(_) => write!(f, "Deniable Message"),
+            MessageKind::BlockRequest(_) => write!(f, "Block Request"),
+            MessageKind::KeyRequest(_) => write!(f, "Key Request"),
+            MessageKind::KeyResponse(_) => write!(f, "Key Response"),
+            MessageKind::SeedUpdate(_) => write!(f, "Seed Update"),
+            MessageKind::Error(_) => write!(f, "Error"),
+        }
     }
 }

--- a/e2e/tests/account.rs
+++ b/e2e/tests/account.rs
@@ -64,7 +64,7 @@ pub async fn one_client_can_register(
             &Uuid::new_v4().to_string(),
             "alice device",
             client_tls,
-            InMemorySendingBuffer::new(0.5).expect("Can make sending buffer"),
+            InMemorySendingBuffer::new(0.0).expect("Can make sending buffer"),
             InMemoryReceivingBuffer::default(),
         )
         .await;
@@ -101,7 +101,7 @@ pub async fn can_delete_account(
         &Uuid::new_v4().to_string(),
         "Alice's device",
         None,
-        InMemorySendingBuffer::new(0.5).expect("can make sending buffer"),
+        InMemorySendingBuffer::new(0.0).expect("can make sending buffer"),
         InMemoryReceivingBuffer::default(),
     )
     .await;
@@ -137,7 +137,7 @@ pub async fn can_delete_a_device(
         &Uuid::new_v4().to_string(),
         "Alice's device",
         None,
-        InMemorySendingBuffer::new(0.5).expect("can make sending buffer"),
+        InMemorySendingBuffer::new(0.0).expect("can make sending buffer"),
         InMemoryReceivingBuffer::default(),
     )
     .await;
@@ -178,7 +178,7 @@ pub async fn alice_can_find_bobs_account_id(
         &Uuid::new_v4().to_string(),
         "Alice's device",
         None,
-        InMemorySendingBuffer::new(0.5).expect("can make sending buffer"),
+        InMemorySendingBuffer::new(0.0).expect("can make sending buffer"),
         InMemoryReceivingBuffer::default(),
     )
     .await;
@@ -190,7 +190,7 @@ pub async fn alice_can_find_bobs_account_id(
         &bob_username,
         "Bob's device",
         None,
-        InMemorySendingBuffer::new(0.5).expect("can make sending buffer"),
+        InMemorySendingBuffer::new(0.0).expect("can make sending buffer"),
         InMemoryReceivingBuffer::default(),
     )
     .await;
@@ -231,7 +231,7 @@ pub async fn two_clients_cannot_have_the_same_username(
         &username,
         "Alice's device",
         None,
-        InMemorySendingBuffer::new(0.5).expect("can make sending buffer"),
+        InMemorySendingBuffer::new(0.0).expect("can make sending buffer"),
         InMemoryReceivingBuffer::default(),
     )
     .await;
@@ -247,7 +247,7 @@ pub async fn two_clients_cannot_have_the_same_username(
             proxy.address().to_string(),
             None,
             10,
-            InMemorySendingBuffer::new(0.5).expect("can make sending buffer"),
+            InMemorySendingBuffer::new(0.0).expect("can make sending buffer"),
             InMemoryReceivingBuffer::default(),
         ))
         .call()

--- a/e2e/tests/device.rs
+++ b/e2e/tests/device.rs
@@ -46,7 +46,7 @@ async fn can_link_device(
         &Uuid::new_v4().to_string(),
         "Alice's device",
         None,
-        InMemorySendingBuffer::new(0.5).expect("can make sending buffer"),
+        InMemorySendingBuffer::new(0.0).expect("can make sending buffer"),
         InMemoryReceivingBuffer::default(),
     )
     .await;
@@ -78,7 +78,7 @@ async fn can_link_device(
             proxy.address().to_owned(),
             None,
             10,
-            InMemorySendingBuffer::new(0.5).expect("can make sending buffer"),
+            InMemorySendingBuffer::new(0.0).expect("can make sending buffer"),
             InMemoryReceivingBuffer::default(),
         ))
         .device_name("Alice's Other Device")
@@ -118,7 +118,7 @@ async fn can_unlink_device(
         &Uuid::new_v4().to_string(),
         "Alice's device",
         None,
-        InMemorySendingBuffer::new(0.5).expect("can make sending buffer"),
+        InMemorySendingBuffer::new(0.0).expect("can make sending buffer"),
         InMemoryReceivingBuffer::default(),
     )
     .await;
@@ -150,7 +150,7 @@ async fn can_unlink_device(
             proxy.address().to_owned(),
             None,
             10,
-            InMemorySendingBuffer::new(0.5).expect("can make sending buffer"),
+            InMemorySendingBuffer::new(0.0).expect("can make sending buffer"),
             InMemoryReceivingBuffer::default(),
         ))
         .device_name("Alice's Other Device")
@@ -191,7 +191,7 @@ async fn can_delete_device(
         &Uuid::new_v4().to_string(),
         "Alice's device",
         None,
-        InMemorySendingBuffer::new(0.5).expect("can make sending buffer"),
+        InMemorySendingBuffer::new(0.0).expect("can make sending buffer"),
         InMemoryReceivingBuffer::default(),
     )
     .await;
@@ -223,7 +223,7 @@ async fn can_delete_device(
             proxy.address().to_owned(),
             None,
             10,
-            InMemorySendingBuffer::new(0.5).expect("can make sending buffer"),
+            InMemorySendingBuffer::new(0.0).expect("can make sending buffer"),
             InMemoryReceivingBuffer::default(),
         ))
         .device_name("Alice's Other Device")
@@ -263,7 +263,7 @@ async fn can_delete_account(
         &Uuid::new_v4().to_string(),
         "Alice's device",
         None,
-        InMemorySendingBuffer::new(0.5).expect("can make sending buffer"),
+        InMemorySendingBuffer::new(0.0).expect("can make sending buffer"),
         InMemoryReceivingBuffer::default(),
     )
     .await;

--- a/e2e/tests/keys.rs
+++ b/e2e/tests/keys.rs
@@ -41,7 +41,7 @@ pub async fn alice_can_upload_keys(
         &Uuid::new_v4().to_string(),
         "Alice's device",
         None,
-        InMemorySendingBuffer::new(0.5).expect("can make sending buffer"),
+        InMemorySendingBuffer::new(0.0).expect("can make sending buffer"),
         InMemoryReceivingBuffer::default(),
     )
     .await;

--- a/e2e/tests/message.rs
+++ b/e2e/tests/message.rs
@@ -57,7 +57,7 @@ async fn alice_send_to_charlie(
         &Uuid::new_v4().to_string(),
         "alice device",
         None,
-        InMemorySendingBuffer::new(0.5).expect("Can make sending buffer"),
+        InMemorySendingBuffer::new(0.0).expect("Can make sending buffer"),
         InMemoryReceivingBuffer::default(),
     )
     .await;
@@ -68,7 +68,7 @@ async fn alice_send_to_charlie(
         &Uuid::new_v4().to_string(),
         "bob device",
         None,
-        InMemorySendingBuffer::new(0.5).expect("Can make sending buffer"),
+        InMemorySendingBuffer::new(0.0).expect("Can make sending buffer"),
         InMemoryReceivingBuffer::default(),
     )
     .await;
@@ -79,7 +79,7 @@ async fn alice_send_to_charlie(
         &Uuid::new_v4().to_string(),
         "charlie device",
         None,
-        InMemorySendingBuffer::new(0.5).expect("Can make sending buffer"),
+        InMemorySendingBuffer::new(0.0).expect("Can make sending buffer"),
         InMemoryReceivingBuffer::default(),
     )
     .await;
@@ -206,7 +206,7 @@ async fn alice_cannot_send_to_charlie_if_blocked(
         &Uuid::new_v4().to_string(),
         "alice device",
         None,
-        InMemorySendingBuffer::new(0.5).expect("Can make sending buffer"),
+        InMemorySendingBuffer::new(0.0).expect("Can make sending buffer"),
         InMemoryReceivingBuffer::default(),
     )
     .await;
@@ -217,7 +217,7 @@ async fn alice_cannot_send_to_charlie_if_blocked(
         &Uuid::new_v4().to_string(),
         "bob device",
         None,
-        InMemorySendingBuffer::new(0.5).expect("Can make sending buffer"),
+        InMemorySendingBuffer::new(0.0).expect("Can make sending buffer"),
         InMemoryReceivingBuffer::default(),
     )
     .await;
@@ -228,7 +228,7 @@ async fn alice_cannot_send_to_charlie_if_blocked(
         &Uuid::new_v4().to_string(),
         "charlie device",
         None,
-        InMemorySendingBuffer::new(0.5).expect("Can make sending buffer"),
+        InMemorySendingBuffer::new(0.0).expect("Can make sending buffer"),
         InMemoryReceivingBuffer::default(),
     )
     .await;
@@ -239,7 +239,7 @@ async fn alice_cannot_send_to_charlie_if_blocked(
         &Uuid::new_v4().to_string(),
         "dorothy device",
         None,
-        InMemorySendingBuffer::new(0.5).expect("Can make sending buffer"),
+        InMemorySendingBuffer::new(0.0).expect("Can make sending buffer"),
         InMemoryReceivingBuffer::default(),
     )
     .await;
@@ -403,7 +403,7 @@ async fn key_request_waits_for_seed_update(
         &Uuid::new_v4().to_string(),
         "alice device",
         None,
-        InMemorySendingBuffer::new(0.5).expect("Can make sending buffer"),
+        InMemorySendingBuffer::new(0.0).expect("Can make sending buffer"),
         InMemoryReceivingBuffer::default(),
     )
     .await;
@@ -414,7 +414,7 @@ async fn key_request_waits_for_seed_update(
         &Uuid::new_v4().to_string(),
         "bob device",
         None,
-        InMemorySendingBuffer::new(0.5).expect("Can make sending buffer"),
+        InMemorySendingBuffer::new(0.0).expect("Can make sending buffer"),
         InMemoryReceivingBuffer::default(),
     )
     .await;
@@ -425,7 +425,7 @@ async fn key_request_waits_for_seed_update(
         &Uuid::new_v4().to_string(),
         "charlie device",
         None,
-        InMemorySendingBuffer::new(0.5).expect("Can make sending buffer"),
+        InMemorySendingBuffer::new(0.0).expect("Can make sending buffer"),
         InMemoryReceivingBuffer::default(),
     )
     .await;
@@ -573,7 +573,7 @@ async fn update_seed(
         &Uuid::new_v4().to_string(),
         "alice device",
         None,
-        InMemorySendingBuffer::new(0.5).expect("Can make sending buffer"),
+        InMemorySendingBuffer::new(0.0).expect("Can make sending buffer"),
         InMemoryReceivingBuffer::default(),
     )
     .await;
@@ -584,7 +584,7 @@ async fn update_seed(
         &Uuid::new_v4().to_string(),
         "bob device",
         None,
-        InMemorySendingBuffer::new(0.5).expect("Can make sending buffer"),
+        InMemorySendingBuffer::new(0.0).expect("Can make sending buffer"),
         InMemoryReceivingBuffer::default(),
     )
     .await;
@@ -595,7 +595,7 @@ async fn update_seed(
         &Uuid::new_v4().to_string(),
         "charlie device",
         None,
-        InMemorySendingBuffer::new(0.5).expect("Can make sending buffer"),
+        InMemorySendingBuffer::new(0.0).expect("Can make sending buffer"),
         InMemoryReceivingBuffer::default(),
     )
     .await;
@@ -724,7 +724,7 @@ async fn deniable_messages_gets_enqueued_when_no_bundle_received(
         &Uuid::new_v4().to_string(),
         "alice device",
         None,
-        InMemorySendingBuffer::new(0.5).expect("Can make sending buffer"),
+        InMemorySendingBuffer::new(0.0).expect("Can make sending buffer"),
         InMemoryReceivingBuffer::default(),
     )
     .await;
@@ -767,7 +767,7 @@ async fn ongoing_communication(
         &Uuid::new_v4().to_string(),
         "alice device",
         None,
-        InMemorySendingBuffer::new(0.5).expect("Can make sending buffer"),
+        InMemorySendingBuffer::new(0.0).expect("Can make sending buffer"),
         InMemoryReceivingBuffer::default(),
     )
     .await;
@@ -778,7 +778,7 @@ async fn ongoing_communication(
         &Uuid::new_v4().to_string(),
         "bob device",
         None,
-        InMemorySendingBuffer::new(0.5).expect("Can make sending buffer"),
+        InMemorySendingBuffer::new(0.0).expect("Can make sending buffer"),
         InMemoryReceivingBuffer::default(),
     )
     .await;
@@ -789,7 +789,7 @@ async fn ongoing_communication(
         &Uuid::new_v4().to_string(),
         "charlie device",
         None,
-        InMemorySendingBuffer::new(0.5).expect("Can make sending buffer"),
+        InMemorySendingBuffer::new(0.0).expect("Can make sending buffer"),
         InMemoryReceivingBuffer::default(),
     )
     .await;
@@ -800,7 +800,7 @@ async fn ongoing_communication(
         &Uuid::new_v4().to_string(),
         "dorothy device",
         None,
-        InMemorySendingBuffer::new(0.5).expect("Can make sending buffer"),
+        InMemorySendingBuffer::new(0.0).expect("Can make sending buffer"),
         InMemoryReceivingBuffer::default(),
     )
     .await;

--- a/e2e/tests/proxy.rs
+++ b/e2e/tests/proxy.rs
@@ -58,7 +58,7 @@ async fn can_connect(
             &Uuid::new_v4().to_string(),
             "alice device",
             client_tls,
-            InMemorySendingBuffer::new(0.5).expect("Can make sending buffer"),
+            InMemorySendingBuffer::new(0.0).expect("Can make sending buffer"),
             InMemoryReceivingBuffer::default(),
         )
         .await;
@@ -101,7 +101,7 @@ async fn can_send_message(
             &Uuid::new_v4().to_string(),
             "alice device",
             client_tls.clone(),
-            InMemorySendingBuffer::new(0.5).expect("Can make sending buffer"),
+            InMemorySendingBuffer::new(0.0).expect("Can make sending buffer"),
             InMemoryReceivingBuffer::default(),
         )
         .await;
@@ -111,7 +111,7 @@ async fn can_send_message(
             &Uuid::new_v4().to_string(),
             "bob device",
             client_tls,
-            InMemorySendingBuffer::new(0.5).expect("Can make sending buffer"),
+            InMemorySendingBuffer::new(0.0).expect("Can make sending buffer"),
             InMemoryReceivingBuffer::default(),
         )
         .await;

--- a/proxy/src/denim_routes.rs
+++ b/proxy/src/denim_routes.rs
@@ -33,15 +33,19 @@ pub async fn denim_router<T: DenimStateType>(
 ) -> Result<(), DenimRouterError> {
     match request {
         ClientRequest::BlockRequest(_, block_request) => {
+            debug!("Received Block Request");
             handle_block_request(state, block_request, account_id).await
         }
         ClientRequest::KeyRequest(msg_id, key_request) => {
+            debug!("Received Key Request");
             handle_key_request(state, msg_id, key_request, account_id).await
         }
         ClientRequest::SeedUpdateRequest(msg_id, seed_update) => {
+            debug!("Received Seed Update Request");
             handle_seed_update(state, msg_id, seed_update, account_id).await
         }
         ClientRequest::UserMessage(_, message) => {
+            debug!("Received User Message Request");
             handle_user_message(state, message, account_id).await
         }
     }
@@ -161,6 +165,7 @@ pub async fn enqueue_message<T: DenimStateType>(
     message: MessageKind,
     receiver: AccountId,
 ) -> Result<(), DenimRouterError> {
+    debug!("Enqueued {}", message);
     state
         .buffer_manager
         .enqueue_message(


### PR DESCRIPTION
Q was only set on the sendingbuffer in the protocol receiver, meaning the sending buffer the client uses to send messages always using Q=0.0 which leads to no deniable messages being sent.